### PR TITLE
Default home.spec.js test import

### DIFF
--- a/test/unit/specs/Home.spec.js
+++ b/test/unit/specs/Home.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { mount } from '@vue/test-utils';
-import Home from '@/pages/Home/Index.vue';
+import Home from '@/views/Home/Index.vue';
 
 describe('Home index.vue', () => {
   it('should render correct contents', () => {


### PR DESCRIPTION
Just a small fix for the default home.spec.js test which imports the tested component from ( i think ) an old path. 